### PR TITLE
close testfile.yaml

### DIFF
--- a/aconfigyaml/yaml.go
+++ b/aconfigyaml/yaml.go
@@ -17,6 +17,7 @@ func New() *Decoder { return &Decoder{} }
 // DecodeFile implements aconfig.FileDecoder.
 func (d *Decoder) DecodeFile(filename string) (map[string]interface{}, error) {
 	f, err := os.Open(filename)
+	defer f.Close()
 	if err != nil {
 		return nil, err
 	}

--- a/aconfigyaml/yaml_test.go
+++ b/aconfigyaml/yaml_test.go
@@ -73,6 +73,7 @@ func createTestFile(t *testing.T) string {
 	filepath := dir + "/testfile.yaml"
 
 	f, err := os.Create(filepath)
+	defer f.Close()
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
in go1.16 failed test aconfigyaml because testfile.yaml lock to remove.