### PR TITLE
If FileFlag set and not use, aconfig override Files with empty string 

### DIFF
--- a/aconfig.go
+++ b/aconfig.go
@@ -259,10 +259,12 @@ func (l *Loader) loadFromFile() error {
 		flag := l.flagSet.Lookup(l.config.FileFlag)
 		if flag != nil {
 			configFile := flag.Value.String()
-			if l.config.MergeFiles {
-				l.config.Files = append(l.config.Files, configFile)
-			} else {
-				l.config.Files = []string{configFile}
+			if configFile != "" {
+				if l.config.MergeFiles {
+					l.config.Files = append(l.config.Files, configFile)
+				} else {
+					l.config.Files = []string{configFile}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Config example:
```
aconfig.Config{
		SkipFiles:          false,
		SkipFlags:          false,
		FailOnFileNotFound: true,
		MergeFiles:         false,
		FileFlag:           "cfg",
		Files:              []string{"conf/settings.yaml"},
```

if run binary without -cfg flag,  Files become  []string{""}