### PR TITLE
Fix deep file parsing not working when flag delimiter is set

### DIFF
--- a/aconfig_test.go
+++ b/aconfig_test.go
@@ -1450,3 +1450,35 @@ func TestBad(t *testing.T) {
 		t.Fatalf("want %v, got %v", want, got)
 	}
 }
+
+func TestFileConfigFlagDelim(t *testing.T) {
+	type TestConfig struct {
+		Options struct {
+			Foo float64
+			Bar float64
+		}
+	}
+	var cfg TestConfig
+
+	loader := LoaderFor(&cfg, Config{
+		SkipDefaults:  true,
+		SkipEnv:       true,
+		SkipFlags:     true,
+		FlagDelimiter: "_",
+
+		Files: []string{"testdata/toy.json"},
+	})
+
+	if err := loader.Load(); err != nil {
+		t.Fatal(err)
+	}
+
+	var want = TestConfig{Options: struct {
+		Foo float64
+		Bar float64
+	}{0.4, 0.25}}
+
+	if got := cfg; !reflect.DeepEqual(want, got) {
+		t.Fatalf("want %v, got %v", want, got)
+	}
+}

--- a/reflection.go
+++ b/reflection.go
@@ -73,7 +73,10 @@ func (l *Loader) tagsForField(field reflect.StructField) map[string]string {
 }
 
 func (l *Loader) fullTag(prefix string, f *fieldData, tag string) string {
-	sep := l.config.FlagDelimiter
+	sep := "."
+	if tag == flagNameTag {
+		sep = l.config.FlagDelimiter
+	}
 	if tag == envNameTag {
 		sep = l.config.envDelimiter
 	}


### PR DESCRIPTION
File parsing with nested structure doesn't work currently when a different flag delimiter than default "." is set. So I tried to fix that here. 

Couldn't run the full test suite on my machine, so I am not 100% sure that this change doesn't break anything else.