### PR TITLE
fix(#152): migrate toml package

### DIFF
--- a/aconfigtoml/go.mod
+++ b/aconfigtoml/go.mod
@@ -1,8 +1,10 @@
 module github.com/cristalhq/aconfig/aconfigtoml
 
-go 1.16
+go 1.21.0
+
+toolchain go1.23.0
 
 require (
-	github.com/BurntSushi/toml v1.1.0
-	github.com/cristalhq/aconfig v0.17.0
+	github.com/cristalhq/aconfig v0.18.5
+	github.com/pelletier/go-toml/v2 v2.2.3
 )

--- a/aconfigtoml/go.sum
+++ b/aconfigtoml/go.sum
@@ -1,4 +1,12 @@
-github.com/BurntSushi/toml v1.1.0 h1:ksErzDEI1khOiGPgpwuI7x2ebx/uXQNw7xJpn9Eq1+I=
-github.com/BurntSushi/toml v1.1.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
-github.com/cristalhq/aconfig v0.17.0 h1:VYqg0YOM5yUEx0KH/VwUYF2e/PNI7dcUE66y+xEx73s=
-github.com/cristalhq/aconfig v0.17.0/go.mod h1:NXaRp+1e6bkO4dJn+wZ71xyaihMDYPtCSvEhMTm/H3E=
+github.com/cristalhq/aconfig v0.18.5 h1:QqXH/Gy2c4QUQJTV2BN8UAuL/rqZ3IwhvxeC8OgzquA=
+github.com/cristalhq/aconfig v0.18.5/go.mod h1:NXaRp+1e6bkO4dJn+wZ71xyaihMDYPtCSvEhMTm/H3E=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNHvL12M=
+github.com/pelletier/go-toml/v2 v2.2.3/go.mod h1:MfCQTFTvCcUyyvvwm1+G6H/jORL20Xlb6rzQu9GuUkc=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/aconfigtoml/testdata/config.toml
+++ b/aconfigtoml/testdata/config.toml
@@ -1,2 +1,5 @@
 foo = "value1"
 bar = "value2"
+[[foobar]]
+foo = "slice_foo"
+bar = "slice_bar"

--- a/aconfigtoml/toml.go
+++ b/aconfigtoml/toml.go
@@ -3,7 +3,7 @@ package aconfigtoml
 import (
 	"io/fs"
 
-	"github.com/BurntSushi/toml"
+	"github.com/pelletier/go-toml/v2"
 )
 
 // Decoder of TOML files for aconfig.
@@ -28,7 +28,7 @@ func (d *Decoder) DecodeFile(filename string) (map[string]interface{}, error) {
 	defer f.Close()
 
 	var raw map[string]interface{}
-	if _, err := toml.DecodeReader(f, &raw); err != nil {
+	if err := toml.NewDecoder(f).Decode(&raw); err != nil {
 		return nil, err
 	}
 	return raw, nil

--- a/aconfigtoml/toml_test.go
+++ b/aconfigtoml/toml_test.go
@@ -15,8 +15,12 @@ var configEmbed embed.FS
 
 func TestTOMLEmbed(t *testing.T) {
 	var cfg struct {
-		Foo string
-		Bar string
+		Foo    string
+		Bar    string
+		Foobar []struct {
+			Foo string
+			Bar string
+		}
 	}
 	loader := aconfig.LoaderFor(&cfg, aconfig.Config{
 		SkipDefaults:       true,


### PR DESCRIPTION
migrate toml package from [BurntSushi/toml](https://github.com/BurntSushi/toml) to [github.com/pelletier/go-toml/v2](https://github.com/pelletier/go-toml)