### PR TITLE
correct parsing values for slice of strings with commas

### DIFF
--- a/aconfig.go
+++ b/aconfig.go
@@ -98,6 +98,9 @@ type Config struct {
 	//		".env": aconfigdotenv.New(),
 	// 	}
 	FileDecoders map[string]FileDecoder
+
+	// SliceSeparator hold the separator for slice values. Default is ",".
+	SliceSeparator string
 }
 
 // FileDecoder is used to read config from files. See aconfig submodules.
@@ -204,6 +207,10 @@ func (l *Loader) init() {
 	if l.config.FileFlag != "" {
 		// TODO: should be prefixed ?
 		l.flagSet.String(l.config.FileFlag, "", "config file param")
+	}
+
+	if l.config.SliceSeparator == "" {
+		l.config.SliceSeparator = ","
 	}
 }
 

--- a/aconfig_test.go
+++ b/aconfig_test.go
@@ -1618,6 +1618,27 @@ func TestSliceOfDeepStructs(t *testing.T) {
 	mustEqual(t, cfg, want)
 }
 
+func TestSliceOfStrings(t *testing.T) {
+	type TestConfig struct {
+		Strings []string
+	}
+	var cfg TestConfig
+	loader := LoaderFor(&cfg, Config{
+		SkipDefaults: true,
+		SkipEnv:      true,
+		SkipFlags:    true,
+		Files:        []string{"testdata/slice-strings.json"},
+	})
+
+	failIfErr(t, loader.Load())
+
+	want := TestConfig{
+		Strings: []string{"hello", "world", "comma1, comma2, comma3,"},
+	}
+
+	mustEqual(t, cfg, want)
+}
+
 func failIfOk(tb testing.TB, err error) {
 	tb.Helper()
 	if err == nil {

--- a/aconfig_test.go
+++ b/aconfig_test.go
@@ -1624,10 +1624,11 @@ func TestSliceOfStrings(t *testing.T) {
 	}
 	var cfg TestConfig
 	loader := LoaderFor(&cfg, Config{
-		SkipDefaults: true,
-		SkipEnv:      true,
-		SkipFlags:    true,
-		Files:        []string{"testdata/slice-strings.json"},
+		SkipDefaults:   true,
+		SkipEnv:        true,
+		SkipFlags:      true,
+		Files:          []string{"testdata/slice-strings.json"},
+		SliceSeparator: "\u001E",
 	})
 
 	failIfErr(t, loader.Load())

--- a/reflection.go
+++ b/reflection.go
@@ -198,7 +198,7 @@ func (l *Loader) setFieldData(field *fieldData, value interface{}) error {
 
 	case reflect.Slice:
 		if isPrimitive(field.field.Type.Elem()) {
-			return l.setSlice(field, sliceToString(value))
+			return l.setSlice(field, l.sliceToString(value))
 		}
 
 		in := reflect.ValueOf(value)
@@ -314,7 +314,7 @@ func (l *Loader) setSlice(field *fieldData, value string) error {
 		return nil
 	}
 
-	vals := strings.Split(value, sliceSeparator)
+	vals := strings.Split(value, l.config.SliceSeparator)
 	slice := reflect.MakeSlice(field.field.Type, len(vals), len(vals))
 	for i, val := range vals {
 		val = strings.TrimSpace(val)

--- a/reflection.go
+++ b/reflection.go
@@ -314,7 +314,7 @@ func (l *Loader) setSlice(field *fieldData, value string) error {
 		return nil
 	}
 
-	vals := strings.Split(value, ",")
+	vals := strings.Split(value, sliceSeparator)
 	slice := reflect.MakeSlice(field.field.Type, len(vals), len(vals))
 	for i, val := range vals {
 		val = strings.TrimSpace(val)

--- a/testdata/slice-strings.json
+++ b/testdata/slice-strings.json
@@ -1,0 +1,3 @@
+{
+  "strings": [ "hello", "world", "comma1, comma2, comma3," ]
+}

--- a/utils.go
+++ b/utils.go
@@ -11,6 +11,11 @@ import (
 	"unicode"
 )
 
+// sliceSeparator is a separator for slice elements in string.
+// Used unicocde control character 001F - record separator(RS)
+// https://www.unicode.org/charts/nameslist/n_0000.html
+const sliceSeparator = "\u001E"
+
 func assertStruct(x interface{}) {
 	if x == nil {
 		panic("aconfig: destination cannot be nil")
@@ -185,7 +190,7 @@ func sliceToString(curr interface{}) string {
 		b := &strings.Builder{}
 		for i, v := range curr {
 			if i > 0 {
-				b.WriteByte(',')
+				b.WriteString(sliceSeparator)
 			}
 			fmt.Fprint(b, v)
 		}

--- a/utils.go
+++ b/utils.go
@@ -11,11 +11,6 @@ import (
 	"unicode"
 )
 
-// sliceSeparator is a separator for slice elements in string.
-// Used unicocde control character 001E - record separator(RS)
-// https://www.unicode.org/charts/nameslist/n_0000.html
-const sliceSeparator = "\u001E"
-
 func assertStruct(x interface{}) {
 	if x == nil {
 		panic("aconfig: destination cannot be nil")
@@ -184,13 +179,13 @@ func (d *jsonDecoder) DecodeFile(filename string) (map[string]interface{}, error
 	return raw, nil
 }
 
-func sliceToString(curr interface{}) string {
+func (l *Loader) sliceToString(curr interface{}) string {
 	switch curr := curr.(type) {
 	case []interface{}:
 		b := &strings.Builder{}
 		for i, v := range curr {
 			if i > 0 {
-				b.WriteString(sliceSeparator)
+				b.WriteString(l.config.SliceSeparator)
 			}
 			fmt.Fprint(b, v)
 		}

--- a/utils.go
+++ b/utils.go
@@ -12,7 +12,7 @@ import (
 )
 
 // sliceSeparator is a separator for slice elements in string.
-// Used unicocde control character 001F - record separator(RS)
+// Used unicocde control character 001E - record separator(RS)
 // https://www.unicode.org/charts/nameslist/n_0000.html
 const sliceSeparator = "\u001E"
 


### PR DESCRIPTION
Slice of strings can contain strings with commas. Fixed the function for represent such slice into a string. The special unicode character is used as separator, which is described as "record separator".

Fix for #160

