### PR TITLE
Updated mapstructure dependency to maintained version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/cristalhq/aconfig
 
 go 1.18
 
-require github.com/mitchellh/mapstructure v1.5.0
+require github.com/go-viper/mapstructure/v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
-github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/go-viper/mapstructure/v2 v2.4.0 h1:EBsztssimR/CONLSZZ04E8qAkxNYq4Qp9LvH92wZUgs=
+github.com/go-viper/mapstructure/v2 v2.4.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=

--- a/parser.go
+++ b/parser.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 )
 
 type structParser struct {


### PR DESCRIPTION
As per: [https://github.com/cristalhq/aconfig/issues/164](https://github.com/cristalhq/aconfig/issues/164)

Updated github.com/mitchellh/mapstructure dependency to github.com/go-viper/mapstructure/v2